### PR TITLE
[fix] Add C header and remove latest glibc dependency

### DIFF
--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -21,10 +21,10 @@
  * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  * OTHER DEALINGS IN THE SOFTWARE.
  */
-#include <bits/types/wint_t.h>
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
+#include <wchar.h>
 
 #include <mba/msgno.h>
 #include <mba/iterator.h>

--- a/src/text.c
+++ b/src/text.c
@@ -34,7 +34,6 @@
 
 #include <mba/msgno.h>
 #include <mba/text.h>
-#include <bits/types/mbstate_t.h>
 #include <mba/allocator.h>
 
 int


### PR DESCRIPTION
After the changes that were introduced from iwyu some headers were
suggested that were from the latest glibc. That meant systems with older
versions of glibc such as CentOS 7 could not build the library anymore.